### PR TITLE
Add std::formatter specializations for jsrl types 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(JSRL_INSTALL "Generate install target" ON)
 add_library(jsrl
     src/jsrl.cpp
     src/jsrl.hpp
+    src/jsrl_format.hpp
     src/jsrl_general_number.cpp
     src/jsrl_general_number.hpp
     src/jsrl_impl_util.cpp
@@ -80,6 +81,7 @@ if(JSRL_INSTALL)
     # Install headers
     install(FILES
         src/jsrl.hpp
+        src/jsrl_format.hpp
         src/jsrl_general_number.hpp
         src/jsrl_impl_util.hpp
         src/jsrl_mod.hpp

--- a/README.md
+++ b/README.md
@@ -64,6 +64,40 @@ int main() {
 }
 ```
 
+### C++20 std::format Support (Optional)
+
+If building with C++20 or later, JSRL provides `std::formatter` specializations for all JSON types:
+
+```cpp
+#include "jsrl_format.hpp"  // Include for std::format support
+#include <format>
+
+using namespace jsrl;
+
+int main() {
+    Json json = R"({"status": "ok", "count": 42})"_Json;
+
+    // Use std::format with Json objects
+    std::string msg = std::format("Response: {}", json);
+    // msg = "Response: {"status":"ok","count":42}"
+
+    // Works with all jsrl types
+    GeneralNumber num(123);
+    std::cout << std::format("Value: {}", num) << std::endl;
+
+    // Pretty-print with std::format
+    auto pretty = pretty_print(json);
+    std::cout << std::format("{}", pretty) << std::endl;
+
+    return 0;
+}
+```
+
+**Note:** To enable C++20 features, build with:
+```bash
+cmake -DCMAKE_CXX_STANDARD=20 ..
+```
+
 ## Building from Source
 
 ### Requirements

--- a/src/jsrl_format.hpp
+++ b/src/jsrl_format.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -28,6 +28,10 @@
  *
  *  Requires C++20 or later for std::format support.
  */
+
+#ifndef __cpp_lib_format
+#error std::format not supported by the current C++ version or library.
+#endif
 
 namespace std {
 

--- a/src/jsrl_format.hpp
+++ b/src/jsrl_format.hpp
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+#ifndef JSRL_FORMAT_HPP_9A4E7C3B2D1F8E6A5B9C0D3F4E7A2B1C
+#define JSRL_FORMAT_HPP_9A4E7C3B2D1F8E6A5B9C0D3F4E7A2B1C
+
+#include "jsrl.hpp"
+#include "jsrlpp.hpp"
+#include "jsrl_general_number.hpp"
+
+#include <format>
+#include <sstream>
+
+/*! @file jsrl_format.hpp
+ *  @brief std::formatter specializations for jsrl types
+ *
+ *  This header provides std::formatter specializations for jsrl JSON types,
+ *  enabling them to be used with std::format() and related formatting functions.
+ *  All formatters produce output identical to their corresponding operator<< implementations.
+ *
+ *  Requires C++20 or later for std::format support.
+ */
+
+namespace std {
+
+    /*! @brief std::formatter specialization for jsrl::Json
+     *
+     *  Formats Json values using their operator<< implementation,
+     *  producing compact JSON output.
+     */
+    template <>
+    struct formatter<jsrl::Json> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::Json const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+    /*! @brief std::formatter specialization for jsrl::Json::OptionedWrite
+     *
+     *  Formats Json values with custom encoding options (loose floats, UTF-8 handling, etc.).
+     */
+    template <>
+    struct formatter<jsrl::Json::OptionedWrite> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::Json::OptionedWrite const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+    /*! @brief std::formatter specialization for jsrl::JsonPrettyPrint
+     *
+     *  Formats Json values with pretty-printing (indentation, newlines).
+     */
+    template <>
+    struct formatter<jsrl::JsonPrettyPrint> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::JsonPrettyPrint const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+    /*! @brief std::formatter specialization for jsrl::BoundJsonPrettyPrint
+     *
+     *  Formats Json values bound to a specific pretty-print configuration.
+     */
+    template <>
+    struct formatter<jsrl::BoundJsonPrettyPrint> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::BoundJsonPrettyPrint const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+    /*! @brief std::formatter specialization for jsrl::Json::Error
+     *
+     *  Formats Json error objects with their error tag and message.
+     */
+    template <>
+    struct formatter<jsrl::Json::Error> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::Json::Error const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+    /*! @brief std::formatter specialization for jsrl::GeneralNumber
+     *
+     *  Formats GeneralNumber values using their operator<< implementation.
+     */
+    template <>
+    struct formatter<jsrl::GeneralNumber> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return ctx.begin();
+        }
+
+        auto format(jsrl::GeneralNumber const& val, format_context& ctx) const {
+            std::ostringstream oss;
+            oss << val;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+
+} // namespace std
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,3 +43,12 @@ add_jsrl_test(jsrl_general_number_test)
 add_jsrl_test(jsrl_mod_test)
 add_jsrl_test(jsrl_test)
 add_jsrl_test(jsrlpp_test)
+
+# Add format test only if C++20 or later is available
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+    add_jsrl_test(jsrl_format_test)
+    set_target_properties(jsrl_format_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+    )
+endif()

--- a/tests/jsrl_format_test.cpp
+++ b/tests/jsrl_format_test.cpp
@@ -1,0 +1,331 @@
+/**
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+#include "../src/jsrl_format.hpp"
+#include <gtest/gtest.h>
+#include <format>
+#include <sstream>
+#include <string>
+
+namespace {
+    using jsrl::Json;
+    using jsrl::GeneralNumber;
+    using jsrl::JsonPrettyPrint;
+    using jsrl::pretty_print;
+    using std::string;
+    using std::ostringstream;
+
+    /*! @brief Helper function to compare std::format output with operator<< output
+     */
+    template<typename T>
+    void verify_format_matches_ostream(T const& value) {
+        // Get output from operator<<
+        ostringstream oss;
+        oss << value;
+        string ostream_result = oss.str();
+
+        // Get output from std::format
+        string format_result = std::format("{}", value);
+
+        // They should be identical
+        EXPECT_EQ(format_result, ostream_result);
+    }
+
+    // Tests for jsrl::Json formatting
+    TEST(JsonFormatTest, NullValue) {
+        Json json;
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "null");
+    }
+
+    TEST(JsonFormatTest, BooleanTrue) {
+        Json json(true);
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "true");
+    }
+
+    TEST(JsonFormatTest, BooleanFalse) {
+        Json json(false);
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "false");
+    }
+
+    TEST(JsonFormatTest, IntegerValue) {
+        Json json(42);
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "42");
+    }
+
+    TEST(JsonFormatTest, NegativeInteger) {
+        Json json(-123);
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "-123");
+    }
+
+    TEST(JsonFormatTest, FloatingPointValue) {
+        Json json(3.14);
+        verify_format_matches_ostream(json);
+        // Note: exact output may vary based on encoding options
+    }
+
+    TEST(JsonFormatTest, StringValue) {
+        Json json("hello world");
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "\"hello world\"");
+    }
+
+    TEST(JsonFormatTest, StringWithEscapes) {
+        Json json("line1\nline2\ttab");
+        verify_format_matches_ostream(json);
+        // Should have escaped newline and tab
+    }
+
+    TEST(JsonFormatTest, EmptyArray) {
+        Json json(Json::ArrayBody{});
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "[]");
+    }
+
+    TEST(JsonFormatTest, SimpleArray) {
+        Json json(Json::ArrayBody{Json(1), Json(2), Json(3)});
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "[1,2,3]");
+    }
+
+    TEST(JsonFormatTest, EmptyObject) {
+        Json json(Json::ObjectBody{});
+        verify_format_matches_ostream(json);
+        EXPECT_EQ(std::format("{}", json), "{}");
+    }
+
+    TEST(JsonFormatTest, SimpleObject) {
+        Json json(Json::ObjectBody{
+            {"name", Json("John")},
+            {"age", Json(30)}
+        });
+        verify_format_matches_ostream(json);
+        // Note: object key order may vary
+    }
+
+    TEST(JsonFormatTest, NestedStructure) {
+        Json json(Json::ObjectBody{
+            {"user", Json(Json::ObjectBody{
+                {"name", Json("Alice")},
+                {"id", Json(123)}
+            })},
+            {"items", Json(Json::ArrayBody{Json(1), Json(2), Json(3)})}
+        });
+        verify_format_matches_ostream(json);
+    }
+
+    TEST(JsonFormatTest, ParsedJson) {
+        string json_str = R"({"key": ["value1", true, 42]})";
+        Json json = Json::parse(json_str);
+        verify_format_matches_ostream(json);
+    }
+
+    // Tests for jsrl::Json::OptionedWrite formatting
+    TEST(JsonOptionedWriteFormatTest, LooseFloats) {
+        Json json(3.14159);
+        auto optioned = loose_floats(Json::OptionedWrite(json));
+        verify_format_matches_ostream(optioned);
+    }
+
+    TEST(JsonOptionedWriteFormatTest, ExactNumbers) {
+        Json json(1.23456789);
+        auto optioned = exact_numbers(Json::OptionedWrite(json));
+        verify_format_matches_ostream(optioned);
+    }
+
+    // Tests for jsrl::GeneralNumber formatting
+    TEST(GeneralNumberFormatTest, PositiveInteger) {
+        GeneralNumber num(42LL);
+        verify_format_matches_ostream(num);
+        EXPECT_EQ(std::format("{}", num), "42");
+    }
+
+    TEST(GeneralNumberFormatTest, NegativeInteger) {
+        GeneralNumber num(-123LL);
+        verify_format_matches_ostream(num);
+        EXPECT_EQ(std::format("{}", num), "-123");
+    }
+
+    TEST(GeneralNumberFormatTest, Zero) {
+        GeneralNumber num(0LL);
+        verify_format_matches_ostream(num);
+        EXPECT_EQ(std::format("{}", num), "0");
+    }
+
+    TEST(GeneralNumberFormatTest, LargeInteger) {
+        GeneralNumber num(9223372036854775807LL);
+        verify_format_matches_ostream(num);
+    }
+
+    TEST(GeneralNumberFormatTest, FloatingPoint) {
+        GeneralNumber num(3.14159L);
+        verify_format_matches_ostream(num);
+    }
+
+    TEST(GeneralNumberFormatTest, ParsedNumber) {
+        GeneralNumber num = GeneralNumber::parse("123.456");
+        verify_format_matches_ostream(num);
+        // GeneralNumber may format differently than the input string
+        // Just verify the formatter matches operator<<
+    }
+
+    TEST(GeneralNumberFormatTest, ScientificNotation) {
+        GeneralNumber num = GeneralNumber::parse("1.23e10");
+        verify_format_matches_ostream(num);
+    }
+
+    // Tests for jsrl::JsonPrettyPrint formatting
+    TEST(JsonPrettyPrintFormatTest, SimpleObject) {
+        Json json(Json::ObjectBody{
+            {"name", Json("John")},
+            {"age", Json(30)}
+        });
+        auto pretty = pretty_print(json);
+        verify_format_matches_ostream(pretty);
+    }
+
+    TEST(JsonPrettyPrintFormatTest, NestedStructure) {
+        Json json(Json::ObjectBody{
+            {"user", Json(Json::ObjectBody{
+                {"name", Json("Alice")},
+                {"id", Json(123)}
+            })},
+            {"items", Json(Json::ArrayBody{Json(1), Json(2), Json(3)})}
+        });
+        auto pretty = pretty_print(json);
+        verify_format_matches_ostream(pretty);
+
+        // Verify it contains newlines (pretty-printed)
+        string formatted = std::format("{}", pretty);
+        EXPECT_NE(formatted.find('\n'), string::npos);
+    }
+
+    TEST(JsonPrettyPrintFormatTest, OneLine) {
+        Json json(Json::ObjectBody{
+            {"a", Json(1)},
+            {"b", Json(2)}
+        });
+        auto pretty = pretty_print(json).one_line();
+        verify_format_matches_ostream(pretty);
+
+        // Verify it doesn't contain newlines
+        string formatted = std::format("{}", pretty);
+        EXPECT_EQ(formatted.find('\n'), string::npos);
+    }
+
+    TEST(JsonPrettyPrintFormatTest, CustomIndent) {
+        Json json(Json::ObjectBody{
+            {"items", Json(Json::ArrayBody{Json(1), Json(2)})}
+        });
+        auto pretty = pretty_print(json).indent("    ");
+        verify_format_matches_ostream(pretty);
+    }
+
+    // Tests for jsrl::Json::Error formatting
+    TEST(JsonErrorFormatTest, BasicError) {
+        try {
+            Json json;
+            // Trigger a type error by trying to access it as an array
+            json.as_array();
+            FAIL() << "Expected TypeError to be thrown";
+        } catch (Json::TypeError const& e) {
+            // Cast to base class for formatting since only Json::Error has a formatter
+            Json::Error const& base_error = e;
+            verify_format_matches_ostream(base_error);
+
+            // Verify the formatted output contains expected content
+            string formatted = std::format("{}", base_error);
+            EXPECT_NE(formatted.find("Type Error"), string::npos);
+        }
+    }
+
+    TEST(JsonErrorFormatTest, KeyError) {
+        try {
+            Json json(Json::ObjectBody{{"key1", Json(42)}});
+            // Trigger an ObjectKeyError
+            json["nonexistent"];
+            FAIL() << "Expected ObjectKeyError to be thrown";
+        } catch (Json::ObjectKeyError const& e) {
+            // Cast to base class for formatting
+            Json::Error const& base_error = e;
+            verify_format_matches_ostream(base_error);
+
+            string formatted = std::format("{}", base_error);
+            EXPECT_NE(formatted.find("Key Error"), string::npos);
+        }
+    }
+
+    TEST(JsonErrorFormatTest, ArrayKeyError) {
+        try {
+            Json json(Json::ArrayBody{Json(1), Json(2)});
+            // Trigger an ArrayKeyError
+            json[10];
+            FAIL() << "Expected ArrayKeyError to be thrown";
+        } catch (Json::ArrayKeyError const& e) {
+            // Cast to base class for formatting
+            Json::Error const& base_error = e;
+            verify_format_matches_ostream(base_error);
+
+            string formatted = std::format("{}", base_error);
+            EXPECT_NE(formatted.find("Key Error"), string::npos);
+        }
+    }
+
+    TEST(JsonErrorFormatTest, ParseError) {
+        try {
+            Json::parse("{invalid json");
+            FAIL() << "Expected ParseError to be thrown";
+        } catch (Json::ParseError const& e) {
+            // Cast to base class for formatting
+            Json::Error const& base_error = e;
+            verify_format_matches_ostream(base_error);
+
+            string formatted = std::format("{}", base_error);
+            EXPECT_NE(formatted.find("Parsing Error"), string::npos);
+        }
+    }
+
+    // Integration tests - verify formatters can be used in practical scenarios
+    TEST(JsonFormatIntegrationTest, ErrorMessages) {
+        Json num(42);
+        string msg = std::format("Invalid value: {}", num);
+        EXPECT_EQ(msg, "Invalid value: 42");
+    }
+
+    TEST(JsonFormatIntegrationTest, Serialization) {
+        Json json(Json::ObjectBody{
+            {"status", Json("ok")},
+            {"code", Json(200)}
+        });
+        string output = std::format("Response: {}", json);
+        EXPECT_NE(output.find("\"status\""), string::npos);
+        EXPECT_NE(output.find("\"ok\""), string::npos);
+    }
+
+    TEST(JsonFormatIntegrationTest, InlineConversion) {
+        Json value("test");
+        string result = std::format("{}", value);
+        EXPECT_EQ(result, "\"test\"");
+    }
+
+    TEST(JsonFormatIntegrationTest, MultipleValues) {
+        Json name("Alice");
+        Json age(30);
+        string msg = std::format("User: {}, Age: {}", name, age);
+        EXPECT_EQ(msg, "User: \"Alice\", Age: 30");
+    }
+
+} // anonymous namespace

--- a/tests/jsrl_format_test.cpp
+++ b/tests/jsrl_format_test.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -232,6 +232,25 @@ namespace {
         });
         auto pretty = pretty_print(json).indent("    ");
         verify_format_matches_ostream(pretty);
+    }
+
+    TEST(JsonPrettyPrintFormatTest, KeyOrdering) {
+        // Keys inserted in non-alphabetical order; jsrl sorts them lexicographically
+        Json json(Json::ObjectBody{
+            {"zebra", Json(1)},
+            {"apple", Json(2)},
+            {"mango", Json(3)}
+        });
+        auto pretty = pretty_print(json);
+        verify_format_matches_ostream(pretty);
+
+        // Keys must appear in alphabetical order: apple, mango, zebra
+        string formatted = std::format("{}", pretty);
+        auto apple_pos = formatted.find("\"apple\"");
+        auto mango_pos = formatted.find("\"mango\"");
+        auto zebra_pos = formatted.find("\"zebra\"");
+        EXPECT_LT(apple_pos, mango_pos);
+        EXPECT_LT(mango_pos, zebra_pos);
     }
 
     // Tests for jsrl::Json::Error formatting


### PR DESCRIPTION
## Description

Implements std::formatter specializations for jsrl::Json, jsrl::JsonPrettyPrint, jsrl::BoundJsonPrettyPrint, jsrl::Json::OptionedWrite, jsrl::Json::Error, and jsrl::GeneralNumber to enable usage with C++20 std::format().

All formatters produce identical output to their corresponding operator<< implementations.

## Related Issue

https://github.com/adobe/jsrl/issues/1 

## Motivation and Context

This allows convenience when working with std::format in c++20

## How Has This Been Tested?

Unit Testing

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
