### PR TITLE
Add static library symbol visibility support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ generate_export_header(jsrl
     EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/jsrl_export.hpp
 )
 
+# Static library consumers must define JSRL_STATIC_DEFINE so the export
+# header suppresses __declspec(dllimport) / visibility("default") attributes.
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(jsrl PUBLIC JSRL_STATIC_DEFINE)
+endif()
+
 # Define headers for this library
 target_include_directories(jsrl
     PUBLIC


### PR DESCRIPTION
## Description

Define JSRL_STATIC_DEFINE when building static libraries to ensure the generated export header properly suppresses visibility attributes for static consumers. This enables correct symbol visibility behavior for both static and shared library builds

## Motivation and Context

Fixing the conan recipe

## How Has This Been Tested?

Local Testing 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
