### PR TITLE
fix: replace C++ alternative tokens for MSVC default-mode compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14...3.27)
 
 project(jsrl
-    VERSION 1.0.0
+    VERSION 1.0.4
     DESCRIPTION "JSON Serialization and Reading Library - A modern C++ JSON library"
     LANGUAGES CXX
 )

--- a/src/jsrl.cpp
+++ b/src/jsrl.cpp
@@ -60,11 +60,11 @@ namespace jsrl {
 
     void Json::Error::v_print( ostream &os ) const {
         os << what();
-        if ( os and not m_argument.is_null() ) {
+        if ( os && !m_argument.is_null() ) {
             os << " on ";
             try {
                 os << m_argument;
-                if ( not os ) {
+                if ( !os ) {
                     throw EncodeByteError(
                             "Jump into catch block if the write failed." );
                 }
@@ -671,12 +671,12 @@ namespace jsrl {
                     throw Json::EncodeByteError(
                             "String ends in the middle of a UTF-8 sequence" );
                 uint8_t const byte = *cur;
-                if ( not byte_is_utf8_continuation(byte) )
+                if ( !byte_is_utf8_continuation(byte) )
                     throw Json::EncodeByteError(
                             "Continuation byte missing in UTF-8 sequence" );
                 ++cur;
                 primer <<= 6;
-                primer or_eq byte & 0x3F;
+                primer |= byte & 0x3F;
             }
             return primer;
         }
@@ -726,7 +726,7 @@ namespace jsrl {
             } catch ( Json::EncodeByteError const & ) {
                 if ( fail_bad_utf8 )
                     throw;
-                while ( cur != end and byte_is_utf8_continuation( *cur ) )
+                while ( cur != end && byte_is_utf8_continuation( *cur ) )
                     ++cur;
                 return 0xFFFD;
             } catch ( Json::EncodeCodepointError const & ) {
@@ -801,7 +801,7 @@ namespace jsrl {
         }
     }
     void validate_utf8( char const *c, char const *const e ) {
-        bool const nullterminated = not e;
+        bool const nullterminated = !e;
         while ( nullterminated ? *c : c != e )
             scan_valid_utf8_codepoint( c, e );
     }
@@ -976,7 +976,7 @@ namespace jsrl {
         struct CmpNot : private Cmp {
             template<typename P1, typename P2>
             bool operator()( P1 const &p1, P2 const &p2 ) {
-                return not Cmp::operator()( p1, p2 );
+                return !Cmp::operator()( p1, p2 );
             }
         };
         template<typename Comp, typename Iter>
@@ -987,7 +987,7 @@ namespace jsrl {
     }
     void resort( Json::ObjectBody &body ) {
         Json::ObjectBody::iterator mbegin = body.begin(), mend = body.end();
-        if ( not is_strictly_ascending<CmpLt>(mbegin, mend) ) {
+        if ( !is_strictly_ascending<CmpLt>(mbegin, mend) ) {
             reverse( mbegin, mend );
             stable_sort( mbegin, mend, CmpLt() );
             body.erase( unique( mbegin, mend, CmpEq() ), mend );
@@ -1244,7 +1244,7 @@ namespace jsrl {
     Json const &Json::operator[](std::string_view key) const {
         try {
             Json const *element = m_el->find_key( key );
-            if ( not element )
+            if ( !element )
                 throw Json::ObjectKeyError( string(key) );
             return *element;
         } catch ( TypeError const &e ) {
@@ -1349,7 +1349,7 @@ namespace jsrl {
 
     void Json::ParseError::v_print( ostream &os ) const {
         Error::v_print( os );
-        if ( not m_context.empty() )
+        if ( !m_context.empty() )
             write_JSON_string( os << " before ", m_context );
     }
     void Json::ParseError::add_context( streambuf &sbuf, size_t max_bytes ) {
@@ -1652,7 +1652,7 @@ namespace jsrl {
                 s_begin = self.begin(),
                 s_end = self.end();
         const_iterator found = lower_bound( s_begin, s_end, key, CmpLt() );
-        if ( found == s_end or found->first != key )
+        if ( found == s_end || found->first != key )
             return s_end;
         return found;
     }

--- a/src/jsrl.hpp
+++ b/src/jsrl.hpp
@@ -1128,7 +1128,7 @@ namespace jsrl {
     template<typename K>                                                    \
     CPPT Json::get_##TYPE(K &&key, CPPT default_value) const {             \
         Json const *element = find_key( std::forward<K>(key) );             \
-        if ( not element )                                                  \
+        if ( !element )                                                     \
             return default_value;                                           \
         return element->as_##TYPE();                                        \
     }
@@ -1158,7 +1158,7 @@ namespace jsrl {
     Json const &Json::operator[]( size_t index ) const {
         try {
             Json const *element = find_key( index );
-            if ( not element )
+            if ( !element )
                 throw Json::ArrayKeyError( index, size() );
             return *element;
         } catch ( TypeError const &e ) {
@@ -1169,7 +1169,7 @@ namespace jsrl {
     template<typename K, typename D>
     Json Json::get( K &&key, D &&default_val ) const {
         Json const *element = find_key( std::forward<K>(key) );
-        if ( not element )
+        if ( !element )
             return Json( std::forward<D>(default_val) );
         return *element;
     }

--- a/src/jsrl_general_number.cpp
+++ b/src/jsrl_general_number.cpp
@@ -125,7 +125,7 @@ namespace jsrl {
                 need_digit = "No digits after decimal";
                 continue;
             default:
-                if ( not isdigit( byte ) )
+                if ( !isdigit( byte ) )
                     break;
                 need_digit = nullptr;
                 switch ( exponentseen ) {

--- a/src/jsrl_impl_util.cpp
+++ b/src/jsrl_impl_util.cpp
@@ -31,11 +31,11 @@ namespace jsrl {
             int byte = sbuf.sbumpc();
             if ( byte == EOF )
                 throw BadEOFParseError( "Input ended in unicode escape" );
-            if ( byte >= '0' and byte <= '9' )
+            if ( byte >= '0' && byte <= '9' )
                 return byte - '0';
-            if ( byte >= 'a' and byte <= 'f' )
+            if ( byte >= 'a' && byte <= 'f' )
                 return byte - 'a' + 10;
-            if ( byte >= 'A' and byte <= 'F' )
+            if ( byte >= 'A' && byte <= 'F' )
                 return byte - 'A' + 10;
             sbuf.sungetc();
             throw UnexpectedByteParseError(
@@ -45,7 +45,7 @@ namespace jsrl {
             uint16_t codepoint = 0;
             for ( unsigned n = 4; n--; ) {
                 codepoint <<= 4;
-                codepoint or_eq read_hex_digit( sbuf );
+                codepoint |= read_hex_digit( sbuf );
             }
             return codepoint;
         }
@@ -83,9 +83,9 @@ namespace jsrl {
                 if ( ( second_surrogate & ~0x3FF ) != 0xDC00 ) {
                     throw UTFParseError("bad second half of surrogate");
                 }
-                codepoint and_eq 0x03FF;
+                codepoint &= 0x03FF;
                 codepoint <<= 10;
-                codepoint or_eq (second_surrogate & 0x03FF);
+                codepoint |= (second_surrogate & 0x03FF);
                 codepoint += 0x00010000;
             } else if ( ( codepoint & ~0x3FF ) == 0xDC00 ) {
                 throw UTFParseError("orphaned second half of surrogate");
@@ -175,7 +175,7 @@ namespace jsrl {
                     if ( byte == EOF )
                         throw BadEOFParseError( "Incomplete block-comment"
                                 " at end of input" );
-                    if ( byte == '/' and lastbyte == '*' )
+                    if ( byte == '/' && lastbyte == '*' )
                         break;
                 }
                 continue;

--- a/src/jsrlpp.cpp
+++ b/src/jsrlpp.cpp
@@ -100,7 +100,7 @@ namespace jsrl {
                         // and that the key hasn't already been printed.
                         // Then print the found element.
                         if ( found != end( object )
-                                and printed.insert( key ).second )
+                                && printed.insert( key ).second )
                             p_print_key( os, *found, new_linesep, first );
                     }
                 }

--- a/tests/jsrl_test.cpp
+++ b/tests/jsrl_test.cpp
@@ -91,47 +91,47 @@ namespace {
     }
     auto isnt_null( Json const &json ) -> bool
     {
-        return not is_null(json);
+        return !is_null(json);
     }
     auto isnt_bool( Json const &json ) -> bool
     {
-        return not is_bool(json);
+        return !is_bool(json);
     }
     auto isnt_number( Json const &json ) -> bool
     {
-        return not is_number(json);
+        return !is_number(json);
     }
     auto isnt_number_general( Json const &json ) -> bool
     {
-        return not is_number_general(json);
+        return !is_number_general(json);
     }
     auto isnt_number_float( Json const &json ) -> bool
     {
-        return not is_number_float(json);
+        return !is_number_float(json);
     }
     auto isnt_number_integer( Json const &json ) -> bool
     {
-        return not is_number_integer(json);
+        return !is_number_integer(json);
     }
     auto isnt_number_sint( Json const &json ) -> bool
     {
-        return not is_number_sint(json);
+        return !is_number_sint(json);
     }
     auto isnt_number_uint( Json const &json ) -> bool
     {
-        return not is_number_uint(json);
+        return !is_number_uint(json);
     }
     auto isnt_string( Json const &json ) -> bool
     {
-        return not is_string(json);
+        return !is_string(json);
     }
     auto isnt_array( Json const &json ) -> bool
     {
-        return not is_array(json);
+        return !is_array(json);
     }
     auto isnt_object( Json const &json ) -> bool
     {
-        return not is_object(json);
+        return !is_object(json);
     }
 
     auto has_key( Json const &json, string const &key ) -> bool
@@ -140,7 +140,7 @@ namespace {
     }
     auto doesnt_have_key( Json const &json, string const &key ) -> bool
     {
-        return not has_key( json, key );
+        return !has_key( json, key );
     }
 }
 
@@ -728,7 +728,7 @@ TEST( Jsrl,GetAs ) {
         if ( i>=7 ) {
             EXPECT_DOUBLE_EQ( 0.0, json_array.get_number_float(i,0.0) );
             EXPECT_DOUBLE_EQ( 1.0, json_array.get_number_float(i,1.0) );
-        } else if ( i>=2 and i<=3 ) {
+        } else if ( i>=2 && i<=3 ) {
             EXPECT_DOUBLE_EQ( 0.0, json_array.get_number_float(i,0.0) );
             EXPECT_DOUBLE_EQ( 0.0, json_array.get_number_float(i,1.0) );
         } else {
@@ -1019,7 +1019,7 @@ TEST( Jsrl,EOFParse ) {
                     R"JSON({ "" : "" })JSON",
                     "",
                 } ) {
-            if ( not *data and *precursor )
+            if ( !*data && *precursor )
                 continue;
             for ( auto &&trailer : { "  ", "" } ) {
                 [&]{
@@ -1609,7 +1609,7 @@ struct ComparatorTester {
             auto inserted = m_values.insert(
                     make_pair(new_value,vector<pair<Json,unsigned> >{
                         make_pair(new_value,lineno) } ) );
-            if ( not inserted.second ) {
+            if ( !inserted.second ) {
                 FAIL() << "Value at line " << lineno
                         << " is already inserted\nValue "
                         << new_value ;


### PR DESCRIPTION
## Description

 Replace all code-position uses of not/and/or/or_eq/and_eq with their
  and source without requiring /permissive-. Bump version to 1.0.4.

## Related Issue

[conan recipe](https://github.com/conan-io/conan-center-index/pull/29631)

## Motivation and Context

We are having troubles with msvc builds because of using not instead of !

## How Has This Been Tested?

Built and ran tests locally

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
